### PR TITLE
fix coverage issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ script:
 - make driver
 
 after_success:
+- git config credential.helper "store --file=.git/credentials"
+- echo "https://${GHE_TOKEN}:@github.com" > .git/credentials
 - "./scripts/calculateCoverage.sh"
 - "./scripts/publishCoverage.sh"
 


### PR DESCRIPTION
Issue faced right now
```
+git add .
+git commit -m 'Coverage result for commit 214dcdd6b9b504b033bb6b506fc60e7be6de5ad1 from build 482'
[gh-pages 2cb3f06] Coverage result for commit 214dcdd6b9b504b033bb6b506fc60e7be6de5ad1 from build 482
 4 files changed, 4578 insertions(+)
 create mode 100644 coverage/214dcdd6b9b504b033bb6b506fc60e7be6de5ad1/cover.html
 create mode 100644 coverage/master/badge.svg
 create mode 100644 coverage/master/cover.html
 create mode 100644 coverage/master/e2e.svg
+git push origin
remote: No anonymous write access.
fatal: Authentication failed for 'https://:[secure]@github.com/IBM/ibm-vpc-file-csi-driver.git/'
```