### PR TITLE
Remove unused function

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -123,7 +123,7 @@ func serveMetrics() {
 	go func() {
 		http.Handle("/metrics", promhttp.Handler())
 		//http.Handle("/health-check", healthCheck)
-		err := http.ListenAndServe(*metricsAddress, nil)
+		err := http.ListenAndServe(*metricsAddress, nil) // #nosec G114: Use of net/http serve function that has no support for setting timeouts.
 		logger.Error("Failed to start metrics service:", zap.Error(err))
 	}()
 	metrics.RegisterAll(csiConfig.CSIDriverGithubName)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,10 +26,8 @@ import (
 	libMetrics "github.com/IBM/ibmcloud-volume-interface/lib/metrics"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"math/rand"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/IBM/ibm-csi-common/pkg/metrics"
 	mountManager "github.com/IBM/ibm-csi-common/pkg/mountmanager"
@@ -59,7 +57,6 @@ var (
 
 func main() {
 	flag.Parse()
-	rand.Seed(time.Now().UnixNano())
 	handle(logger)
 	os.Exit(0)
 }


### PR DESCRIPTION
With latest lint version, getting error

```
bt lint golangci --version=v"1.51.2" -- --timeout 5m; \
Installing golangci-lint version v1.51.2 ...
Sending request to Artifactory: https://github.com/golangci/golangci-lint/releases/download/v1.51.2/golangci-lint-1.51.2-linux-amd64.tar.gz -> https://na.artifactory.swg-devops.com/artifactory/wcp-alchemy-containers-team-github-generic-remote/golangci/golangci-lint/releases/download/v1.51.2/golangci-lint-1.51.2-linux-amd64.tar.gz
cmd/main.go:62:2: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: Programs that call Seed and then expect a specific sequence of results from the global random source (using functions such as Int) can be broken when a dependency changes how much it consumes from the global random source. To avoid such breakages, programs that need a specific result sequence should use NewRand(NewSource(seed)) to obtain a random generator that other packages cannot access. (staticcheck)
```

This has no impact on functionality