### PR TITLE
Update plugin registration dir

### DIFF
--- a/deploy/kubernetes/driver/kubernetes/manifests/node-server.yaml
+++ b/deploy/kubernetes/driver/kubernetes/manifests/node-server.yaml
@@ -42,7 +42,7 @@ spec:
                   name: ibm-vpc-file-csi-configmap
                   key:  CSI_ADDRESS
             - name: DRIVER_REGISTRATION_SOCK
-              value: /var/lib/kubelet/csi-plugins/vpc.file.csi.ibm.io/csi-vpc-file.sock
+              value: /var/lib/kubelet/plugins/vpc.file.csi.ibm.io/csi-vpc-file.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -184,7 +184,7 @@ spec:
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/csi-plugins/vpc.file.csi.ibm.io/
+            path: /var/lib/kubelet/plugins/vpc.file.csi.ibm.io/
             type: DirectoryOrCreate
         - name: device-dir
           hostPath:

--- a/pkg/ibmcsidriver/server.go
+++ b/pkg/ibmcsidriver/server.go
@@ -174,4 +174,5 @@ func removeCSISocket(endPoint string) {
 		glog.Errorf("failed to remove socket: %s with error: %+v", endPoint, err)
 		os.Exit(1)
 	}
+	os.Exit(0)
 }

--- a/pkg/ibmcsidriver/server.go
+++ b/pkg/ibmcsidriver/server.go
@@ -24,7 +24,9 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/glog"
@@ -131,6 +133,7 @@ func (s *nonBlockingGRPCServer) Setup(endpoint string, ids csi.IdentityServer, c
 	if ns != nil {
 		csi.RegisterNodeServer(s.server, ns)
 	}
+	go removeCSISocket(addr)
 	return listener, nil
 }
 
@@ -159,4 +162,16 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 		glog.V(5).Infof("GRPC response: %+v", resp)
 	}
 	return resp, err
+}
+
+func removeCSISocket(endPoint string) {
+	// Reference: https://github.com/kubernetes-csi/node-driver-registrar/blob/master/cmd/csi-node-driver-registrar/node_register.go#L168
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, syscall.SIGTERM)
+	<-sigc
+	err := os.Remove(endPoint)
+	if err != nil && !os.IsNotExist(err) {
+		glog.Errorf("failed to remove socket: %s with error: %+v", endPoint, err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Driver uses var/lib/kubelet/csi-plugins/. This PR has below changes

1. Move from var/lib/kubelet/csi-plugins/ to var/lib/kubelet/plugins/
2. Cleanup socket during uninstallation

Note: Deleting the node-server will only delete the `/var/lib/kubelet/plugins/vpc.file.csi.ibm.io/csi-vpc-file.sock` because controller server does not have the /var/lib dir mounted