### PR TITLE
Volume Expansion - Remove unused nodeExpand logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/golang/glog v1.0.0
 	github.com/google/uuid v1.3.0
 	github.com/kubernetes-csi/csi-test/v4 v4.4.0
-	github.com/onsi/gomega v1.23.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/zap v1.20.0
@@ -30,7 +29,6 @@ require (
 	github.com/BurntSushi/toml v1.0.0 // indirect
 	github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.6.7 // indirect
 	github.com/IBM/go-sdk-core/v5 v5.9.1 // indirect
-	github.com/IBM/ibmcloud-volume-vpc v1.1.5 // indirect
 	github.com/IBM/secret-common-lib v1.1.4 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -77,6 +75,7 @@ require (
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
+	github.com/onsi/gomega v1.23.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/IBM/ibmcloud-volume-file-vpc v1.2.0 h1:9SQbQPt3RTXd1k2bF129en8s61Nx13
 github.com/IBM/ibmcloud-volume-file-vpc v1.2.0/go.mod h1:GlUHqdDEhi5Lbw2fHq48DH68s7pZfOwH/h/dE6bXX18=
 github.com/IBM/ibmcloud-volume-interface v1.2.1 h1:h7bi/fQzFFvqN2nGxtAfnbYIw3CQetZ8YPAF/g7IQ2Y=
 github.com/IBM/ibmcloud-volume-interface v1.2.1/go.mod h1:646HOeq8dAKbgpr7jRehGKckhgduJyII2uN5T6RDLww=
-github.com/IBM/ibmcloud-volume-vpc v1.1.5 h1:dN/LxVxtkiK0g4JzDP2VnHoh+LfHwPyzB+TgUZbhVyU=
-github.com/IBM/ibmcloud-volume-vpc v1.1.5/go.mod h1:+UTHGrGzjyA2VjaozhB1xOjAcJ1lsi9mFqfGsqmuCOQ=
 github.com/IBM/secret-common-lib v1.1.4 h1:gKpKnaP45Y6u7VpSlFfXjjTAHpu4bz9Ofy+aR0t2RcI=
 github.com/IBM/secret-common-lib v1.1.4/go.mod h1:0L/lLfwi5jwTTmNYE2246HzBIdGz0m6wu/5tXoRp/Lc=
 github.com/IBM/secret-utils-lib v1.1.4 h1:8WPG9KBrLLRhGbQn34NWzrFKlyfIIaUfLeDg+iRJkes=

--- a/pkg/ibmcsidriver/controller.go
+++ b/pkg/ibmcsidriver/controller.go
@@ -500,7 +500,7 @@ func (csiCS *CSIControllerServer) ControllerExpandVolume(ctx context.Context, re
 	if err != nil {
 		return nil, commonError.GetCSIError(ctxLogger, commonError.InternalError, requestID, err)
 	}
-	return &csi.ControllerExpandVolumeResponse{CapacityBytes: capacity, NodeExpansionRequired: true}, nil
+	return &csi.ControllerExpandVolumeResponse{CapacityBytes: capacity, NodeExpansionRequired: false}, nil
 }
 
 // ControllerPublishVolume ...

--- a/pkg/ibmcsidriver/controller_test.go
+++ b/pkg/ibmcsidriver/controller_test.go
@@ -1036,7 +1036,7 @@ func TestControllerExpandVolume(t *testing.T) {
 		{
 			name:                 "Success controller expand volume",
 			req:                  &csi.ControllerExpandVolumeRequest{VolumeId: "volumeid:accesspointID", CapacityRange: stdCapRange},
-			expResponse:          &csi.ControllerExpandVolumeResponse{CapacityBytes: stdCapRange.RequiredBytes, NodeExpansionRequired: true},
+			expResponse:          &csi.ControllerExpandVolumeResponse{CapacityBytes: stdCapRange.RequiredBytes, NodeExpansionRequired: false},
 			expErrCode:           codes.OK,
 			libExpandResponse:    &http.Response{StatusCode: http.StatusOK},
 			libVolumeResponse:    &provider.Volume{Capacity: &cap, Name: &volName, VolumeID: "volumeid", Iops: &iopsStr, Az: "myzone", Region: "myregion"},

--- a/pkg/ibmcsidriver/ibm_csi_driver.go
+++ b/pkg/ibmcsidriver/ibm_csi_driver.go
@@ -97,7 +97,7 @@ func (icDriver *IBMCSIDriver) SetupIBMCSIDriver(provider cloudProvider.CloudProv
 	ns := []csi.NodeServiceCapability_RPC_Type{
 		//csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
-		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+		//csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
 	}
 	_ = icDriver.AddNodeServiceCapabilities(ns) // #nosec G104: Attempt to AddNodeServiceCapabilities only on best-effort basis. Error cannot be usefully handled.
 

--- a/pkg/ibmcsidriver/node.go
+++ b/pkg/ibmcsidriver/node.go
@@ -285,9 +285,10 @@ func (csiNS *CSINodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.Nod
 
 // NodeExpandVolume ...
 func (csiNS *CSINodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
-	ctxLogger, requestID := utils.GetContextLogger(ctx, false)
+	ctxLogger, _ := utils.GetContextLogger(ctx, false)
 	ctxLogger.Info("CSINodeServer-NodeExpandVolume", zap.Reflect("Request", *req))
-	return nil, commonError.GetCSIError(ctxLogger, commonError.MethodUnsupported, requestID, nil, "NodeExpandVolume")
+	return &csi.NodeExpandVolumeResponse{CapacityBytes: req.CapacityRange.RequiredBytes}, nil
+	//return nil, commonError.GetCSIError(ctxLogger, commonError.MethodUnsupported, requestID, nil, "NodeExpandVolume")
 	// ctxLogger, requestID := utils.GetContextLogger(ctx, false)
 	// ctxLogger.Info("CSINodeServer-NodeExpandVolume", zap.Reflect("Request", *req))
 	// volumeID := req.GetVolumeId()

--- a/pkg/ibmcsidriver/node.go
+++ b/pkg/ibmcsidriver/node.go
@@ -274,9 +274,9 @@ func (csiNS *CSINodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.Nod
 
 // NodeExpandVolume ...
 func (csiNS *CSINodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
-	ctxLogger, _ := utils.GetContextLogger(ctx, false)
+	ctxLogger, requestID := utils.GetContextLogger(ctx, false)
 	ctxLogger.Info("CSINodeServer-NodeExpandVolume", zap.Reflect("Request", *req))
-	return &csi.NodeExpandVolumeResponse{CapacityBytes: req.CapacityRange.RequiredBytes}, nil
+	return nil, commonError.GetCSIError(ctxLogger, commonError.MethodUnsupported, requestID, nil, "NodeExpandVolume")
 }
 
 // IsDevicePathNotExist ...

--- a/pkg/ibmcsidriver/node.go
+++ b/pkg/ibmcsidriver/node.go
@@ -55,11 +55,6 @@ type StatsUtils interface {
 	IsDevicePathNotExist(devicePath string) bool
 }
 
-// MountUtils ...
-// type MountUtils interface {
-// 	Resize(mounter mountmanager.Mounter, devicePath string, deviceMountPath string) (bool, error)
-// }
-
 // VolumeMountUtils ...
 type VolumeMountUtils struct {
 }
@@ -80,12 +75,6 @@ const (
 )
 
 var _ csi.NodeServer = &CSINodeServer{}
-
-// var mountmgr MountUtils
-
-// func init() {
-// 	mountmgr = &VolumeMountUtils{}
-// }
 
 // NodePublishVolume ...
 func (csiNS *CSINodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
@@ -288,41 +277,6 @@ func (csiNS *CSINodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeE
 	ctxLogger, _ := utils.GetContextLogger(ctx, false)
 	ctxLogger.Info("CSINodeServer-NodeExpandVolume", zap.Reflect("Request", *req))
 	return &csi.NodeExpandVolumeResponse{CapacityBytes: req.CapacityRange.RequiredBytes}, nil
-	//return nil, commonError.GetCSIError(ctxLogger, commonError.MethodUnsupported, requestID, nil, "NodeExpandVolume")
-	// ctxLogger, requestID := utils.GetContextLogger(ctx, false)
-	// ctxLogger.Info("CSINodeServer-NodeExpandVolume", zap.Reflect("Request", *req))
-	// volumeID := req.GetVolumeId()
-	// if len(volumeID) == 0 {
-	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.EmptyVolumeID, requestID, nil)
-	// }
-
-	// deviceMountPath := req.GetVolumePath()
-	// if len(deviceMountPath) == 0 {
-	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.EmptyVolumePath, requestID, nil)
-	// }
-
-	// notMounted, err := csiNS.Mounter.IsLikelyNotMountPoint(deviceMountPath)
-	// if err != nil {
-	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.ObjectNotFound, requestID, err, deviceMountPath)
-	// }
-
-	// if notMounted {
-	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.VolumePathNotMounted, requestID, nil, deviceMountPath)
-	// }
-
-	// devicePath, _, err := mount.GetDeviceNameFromMount(csiNS.Mounter, deviceMountPath)
-	// if err != nil {
-	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.GetDeviceInfoFailed, requestID, err, deviceMountPath)
-	// }
-
-	// if devicePath == "" {
-	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.EmptyDevicePath, requestID, err)
-	// }
-
-	// if _, err := mountmgr.Resize(csiNS.Mounter, devicePath, deviceMountPath); err != nil {
-	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.FileSystemResizeFailed, requestID, err)
-	// }
-	// return &csi.NodeExpandVolumeResponse{CapacityBytes: req.CapacityRange.RequiredBytes}, nil
 }
 
 // IsDevicePathNotExist ...
@@ -336,12 +290,3 @@ func (su *VolumeStatUtils) IsDevicePathNotExist(devicePath string) bool {
 	}
 	return false
 }
-
-// // Resize expands the fs
-// func (volMountUtils *VolumeMountUtils) Resize(mounter mountmanager.Mounter, devicePath string, deviceMountPath string) (bool, error) {
-// 	r := mount.NewResizeFs(mounter.GetSafeFormatAndMount().Exec)
-// 	if _, err := r.Resize(devicePath, deviceMountPath); err != nil {
-// 		return false, err
-// 	}
-// 	return true, nil
-// }

--- a/pkg/ibmcsidriver/node.go
+++ b/pkg/ibmcsidriver/node.go
@@ -56,9 +56,9 @@ type StatsUtils interface {
 }
 
 // MountUtils ...
-type MountUtils interface {
-	Resize(mounter mountmanager.Mounter, devicePath string, deviceMountPath string) (bool, error)
-}
+// type MountUtils interface {
+// 	Resize(mounter mountmanager.Mounter, devicePath string, deviceMountPath string) (bool, error)
+// }
 
 // VolumeMountUtils ...
 type VolumeMountUtils struct {
@@ -80,11 +80,12 @@ const (
 )
 
 var _ csi.NodeServer = &CSINodeServer{}
-var mountmgr MountUtils
 
-func init() {
-	mountmgr = &VolumeMountUtils{}
-}
+// var mountmgr MountUtils
+
+// func init() {
+// 	mountmgr = &VolumeMountUtils{}
+// }
 
 // NodePublishVolume ...
 func (csiNS *CSINodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
@@ -286,38 +287,41 @@ func (csiNS *CSINodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.Nod
 func (csiNS *CSINodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
 	ctxLogger, requestID := utils.GetContextLogger(ctx, false)
 	ctxLogger.Info("CSINodeServer-NodeExpandVolume", zap.Reflect("Request", *req))
-	volumeID := req.GetVolumeId()
-	if len(volumeID) == 0 {
-		return nil, commonError.GetCSIError(ctxLogger, commonError.EmptyVolumeID, requestID, nil)
-	}
+	return nil, commonError.GetCSIError(ctxLogger, commonError.MethodUnsupported, requestID, nil, "NodeExpandVolume")
+	// ctxLogger, requestID := utils.GetContextLogger(ctx, false)
+	// ctxLogger.Info("CSINodeServer-NodeExpandVolume", zap.Reflect("Request", *req))
+	// volumeID := req.GetVolumeId()
+	// if len(volumeID) == 0 {
+	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.EmptyVolumeID, requestID, nil)
+	// }
 
-	deviceMountPath := req.GetVolumePath()
-	if len(deviceMountPath) == 0 {
-		return nil, commonError.GetCSIError(ctxLogger, commonError.EmptyVolumePath, requestID, nil)
-	}
+	// deviceMountPath := req.GetVolumePath()
+	// if len(deviceMountPath) == 0 {
+	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.EmptyVolumePath, requestID, nil)
+	// }
 
-	notMounted, err := csiNS.Mounter.IsLikelyNotMountPoint(deviceMountPath)
-	if err != nil {
-		return nil, commonError.GetCSIError(ctxLogger, commonError.ObjectNotFound, requestID, err, deviceMountPath)
-	}
+	// notMounted, err := csiNS.Mounter.IsLikelyNotMountPoint(deviceMountPath)
+	// if err != nil {
+	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.ObjectNotFound, requestID, err, deviceMountPath)
+	// }
 
-	if notMounted {
-		return nil, commonError.GetCSIError(ctxLogger, commonError.VolumePathNotMounted, requestID, nil, deviceMountPath)
-	}
+	// if notMounted {
+	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.VolumePathNotMounted, requestID, nil, deviceMountPath)
+	// }
 
-	devicePath, _, err := mount.GetDeviceNameFromMount(csiNS.Mounter, deviceMountPath)
-	if err != nil {
-		return nil, commonError.GetCSIError(ctxLogger, commonError.GetDeviceInfoFailed, requestID, err, deviceMountPath)
-	}
+	// devicePath, _, err := mount.GetDeviceNameFromMount(csiNS.Mounter, deviceMountPath)
+	// if err != nil {
+	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.GetDeviceInfoFailed, requestID, err, deviceMountPath)
+	// }
 
-	if devicePath == "" {
-		return nil, commonError.GetCSIError(ctxLogger, commonError.EmptyDevicePath, requestID, err)
-	}
+	// if devicePath == "" {
+	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.EmptyDevicePath, requestID, err)
+	// }
 
-	if _, err := mountmgr.Resize(csiNS.Mounter, devicePath, deviceMountPath); err != nil {
-		return nil, commonError.GetCSIError(ctxLogger, commonError.FileSystemResizeFailed, requestID, err)
-	}
-	return &csi.NodeExpandVolumeResponse{CapacityBytes: req.CapacityRange.RequiredBytes}, nil
+	// if _, err := mountmgr.Resize(csiNS.Mounter, devicePath, deviceMountPath); err != nil {
+	// 	return nil, commonError.GetCSIError(ctxLogger, commonError.FileSystemResizeFailed, requestID, err)
+	// }
+	// return &csi.NodeExpandVolumeResponse{CapacityBytes: req.CapacityRange.RequiredBytes}, nil
 }
 
 // IsDevicePathNotExist ...
@@ -332,11 +336,11 @@ func (su *VolumeStatUtils) IsDevicePathNotExist(devicePath string) bool {
 	return false
 }
 
-// Resize expands the fs
-func (volMountUtils *VolumeMountUtils) Resize(mounter mountmanager.Mounter, devicePath string, deviceMountPath string) (bool, error) {
-	r := mount.NewResizeFs(mounter.GetSafeFormatAndMount().Exec)
-	if _, err := r.Resize(devicePath, deviceMountPath); err != nil {
-		return false, err
-	}
-	return true, nil
-}
+// // Resize expands the fs
+// func (volMountUtils *VolumeMountUtils) Resize(mounter mountmanager.Mounter, devicePath string, deviceMountPath string) (bool, error) {
+// 	r := mount.NewResizeFs(mounter.GetSafeFormatAndMount().Exec)
+// 	if _, err := r.Resize(devicePath, deviceMountPath); err != nil {
+// 		return false, err
+// 	}
+// 	return true, nil
+// }


### PR DESCRIPTION
Test results is GHE https://github.ibm.com/alchemy-containers/armada-storage/issues/5244

This PR will have following support,
- **online expansion** is tested and is working. `nodeExpand` is not required in case of file. Confirmed that the call is not recorded in node server logs
- **offline expansion** is tested and is working with new changes unless current changes were updating the volume updates the share from the backend but PVC is not updated. With new changes, it is working now.