### PR TITLE
Update csidriver.yaml spec

### DIFF
--- a/deploy/kubernetes/driver/kubernetes/manifests/csidriver.yaml
+++ b/deploy/kubernetes/driver/kubernetes/manifests/csidriver.yaml
@@ -4,6 +4,7 @@ metadata:
   name: vpc.file.csi.ibm.io
 spec:
   attachRequired: false
+  fsGroupPolicy: File
   podInfoOnMount: true
   volumeLifecycleModes:
   - Persistent


### PR DESCRIPTION
As per VPC file csi driver use case, we require the k8s to update the ownership of volume via fsGroup in case the volume is used by an application running as non root.