### PR TITLE
KUBE_NODE_NAME is mandatory env for vpc file csi driver

### DIFF
--- a/deploy/kubernetes/driver/kubernetes/manifests/controller-server.yaml
+++ b/deploy/kubernetes/driver/kubernetes/manifests/controller-server.yaml
@@ -100,6 +100,10 @@ spec:
                 configMapKeyRef:
                   name: ibm-vpc-file-csi-configmap
                   key:  CSI_ENDPOINT
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: SIDECAR_ADDRESS
               valueFrom:
                 configMapKeyRef:

--- a/deploy/openshift-self-managed/driver/kubernetes/manifests/controller-server.yaml
+++ b/deploy/openshift-self-managed/driver/kubernetes/manifests/controller-server.yaml
@@ -100,6 +100,10 @@ spec:
                 configMapKeyRef:
                   name: ibm-vpc-file-csi-configmap
                   key:  CSI_ENDPOINT
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: SIDECAR_ADDRESS
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
KUBE_NODE_NAME is mandatory env for vpc file csi driver either it has to be provided by COS or add in the deployment, it was failing on one of IPI cluster