### PR TITLE
Go and greadnaught image upgrade

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write # needed to comment on PRs
     strategy:
       matrix:
-        go-version: ["1.25.9", "stable"]
+        go-version: ["1.25.10", "stable"]
       fail-fast: false
 
     steps:
@@ -66,7 +66,7 @@ jobs:
         run: make driver
 
       - name: Publish coverage
-        if: success() && matrix.go-version == '1.25.9'
+        if: success() && matrix.go-version == '1.25.10'
         env:
           GHE_TOKEN: ${{ secrets.GHE_TOKEN }}
           GHE_USER: github-actions # required for git clone URL in script

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.25.9
+FROM golang:1.25.10
 
 WORKDIR /go/src/github.com/IBM/ibm-vpc-file-csi-driver
 ADD . /go/src/github.com/IBM/ibm-vpc-file-csi-driver

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/ibm-vpc-file-csi-driver
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/IBM/ibm-csi-common v1.1.24


### PR DESCRIPTION
Task Detail :->

DreadNaught image versions are upgraded due to reported VA.

Compliance Issue Details :->

- CVE-2026-33811
- CVE-2026-39979     
- CVE-2025-14512     
- CVE-2025-14087     
- CVE-2026-40164   
- 
Updation Area :->

Dreadnaught image upgrade v9.7.95 to v9.7.98
```
> ic cr va icr.io/ibm-dreadnought-prod-images/ubi9/golang-1.25-builder:v9.7.103
Checking security issues for 'icr.io/ibm-dreadnought-prod-images/ubi9/golang-1.25-builder:v9.7.103'...

Image 'icr.io/ibm-dreadnought-prod-images/ubi9/golang-1.25-builder:v9.7.103' was last scanned on Thu May 14 23:56:05 UTC 2026
The scan results show that NO ISSUES were found for the image.

OK

```