### PR TITLE
Add vmState parameter support for VM persistent state volumes

### DIFF
--- a/pkg/ibmcsidriver/constants.go
+++ b/pkg/ibmcsidriver/constants.go
@@ -184,6 +184,9 @@ const (
 	// SubnetID ...
 	SubnetID = "subnetID"
 
+	// VMState ... Parameter to identify VM persistent state volumes (vTPM)
+	VMState = "vmState"
+
 	// ConfigmapName ...
 	ConfigmapName = "ibm-cloud-provider-data"
 

--- a/pkg/ibmcsidriver/controller_helper.go
+++ b/pkg/ibmcsidriver/controller_helper.go
@@ -259,6 +259,9 @@ func getVolumeParameters(logger *zap.Logger, req *csi.CreateVolumeRequest, confi
 			if gid < 0 {
 				err = fmt.Errorf("%v must be greater or equal than 0", gid)
 			}
+		case VMState:
+			// Accept vmState parameter - validation will be handled elsewhere
+			logger.Info("vmState parameter accepted", zap.String("value", value))
 		default:
 			err = fmt.Errorf("<%s> is an invalid parameter", key)
 		}

--- a/pkg/ibmcsidriver/controller_helper_test.go
+++ b/pkg/ibmcsidriver/controller_helper_test.go
@@ -853,6 +853,119 @@ func TestGetVolumeParameters(t *testing.T) {
 			expectedStatus: true,
 			expectedError:  fmt.Errorf("volume capabilities are empty"),
 		},
+		{
+			testCaseName: "vmState parameter with true value",
+			request: &csi.CreateVolumeRequest{
+				Name: volumeName,
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 11811160064,
+					LimitBytes:    utils.MinimumVolumeSizeInBytes + utils.MinimumVolumeSizeInBytes,
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					}},
+				},
+				Parameters: map[string]string{
+					Profile:       "dp2",
+					Zone:          "us-south-1",
+					Region:        "us-south",
+					VMState:       "true",
+					IsENIEnabled:  "true",
+					ResourceGroup: "myresourcegroups",
+				},
+			},
+			expectedVolume: &provider.Volume{
+				Name:     &volumeName,
+				Capacity: &volumeSize,
+				VPCVolume: provider.VPCVolume{
+					Profile:       &provider.Profile{Name: "dp2"},
+					ResourceGroup: &provider.ResourceGroup{ID: "myresourcegroups"},
+					VPCFileVolume: provider.VPCFileVolume{
+						AccessControlMode: SecurityGroup,
+					},
+				},
+				Az:     "us-south-1",
+				Region: "us-south",
+			},
+			expectedStatus: true,
+			expectedError:  nil,
+		},
+		{
+			testCaseName: "vmState parameter with false value",
+			request: &csi.CreateVolumeRequest{
+				Name: volumeName,
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 11811160064,
+					LimitBytes:    utils.MinimumVolumeSizeInBytes + utils.MinimumVolumeSizeInBytes,
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+					}},
+				},
+				Parameters: map[string]string{
+					Profile:       "dp2",
+					Zone:          "us-south-1",
+					Region:        "us-south",
+					VMState:       "false",
+					IsENIEnabled:  "true",
+					ResourceGroup: "myresourcegroups",
+				},
+			},
+			expectedVolume: &provider.Volume{
+				Name:     &volumeName,
+				Capacity: &volumeSize,
+				VPCVolume: provider.VPCVolume{
+					Profile:       &provider.Profile{Name: "dp2"},
+					ResourceGroup: &provider.ResourceGroup{ID: "myresourcegroups"},
+					VPCFileVolume: provider.VPCFileVolume{
+						AccessControlMode: SecurityGroup,
+					},
+				},
+				Az:     "us-south-1",
+				Region: "us-south",
+			},
+			expectedStatus: true,
+			expectedError:  nil,
+		},
+		{
+			testCaseName: "vmState parameter not provided",
+			request: &csi.CreateVolumeRequest{
+				Name: volumeName,
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 11811160064,
+					LimitBytes:    utils.MinimumVolumeSizeInBytes + utils.MinimumVolumeSizeInBytes,
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+					}},
+				},
+				Parameters: map[string]string{
+					Profile:       "dp2",
+					Zone:          "us-south-1",
+					Region:        "us-south",
+					IsENIEnabled:  "true",
+					ResourceGroup: "myresourcegroups",
+				},
+			},
+			expectedVolume: &provider.Volume{
+				Name:     &volumeName,
+				Capacity: &volumeSize,
+				VPCVolume: provider.VPCVolume{
+					Profile:       &provider.Profile{Name: "dp2"},
+					ResourceGroup: &provider.ResourceGroup{ID: "myresourcegroups"},
+					VPCFileVolume: provider.VPCFileVolume{
+						AccessControlMode: SecurityGroup,
+					},
+				},
+				Az:     "us-south-1",
+				Region: "us-south",
+			},
+			expectedStatus: true,
+			expectedError:  nil,
+		},
 	}
 
 	// Set up


### PR DESCRIPTION
- Added VMState constant to constants.go
- Added vmState parameter acceptance in controller_helper.go
- Added 3 unit test cases for vmState parameter validation
- Fixed test structure to use correct VPCFileVolume hierarchy