### PR TITLE
Revert "Support transitEncryption support based on new APIVersion used"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/IBM/ibm-vpc-file-csi-driver
 go 1.25.10
 
 require (
-	github.com/IBM/ibm-csi-common v1.1.27
-	github.com/IBM/ibmcloud-volume-file-vpc v1.2.20
+	github.com/IBM/ibm-csi-common v1.1.26
+	github.com/IBM/ibmcloud-volume-file-vpc v1.2.19
 	github.com/IBM/ibmcloud-volume-interface v1.2.21
 	github.com/IBM/secret-utils-lib v1.1.16
 	github.com/container-storage-interface/spec v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -7,10 +7,10 @@ github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.6.7 h1:eHgfQl6IeSmzWUyiSi13CvoFYsovoyq
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.6.7/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
 github.com/IBM/go-sdk-core/v5 v5.17.4 h1:VGb9+mRrnS2HpHZFM5hy4J6ppIWnwNrw0G+tLSgcJLc=
 github.com/IBM/go-sdk-core/v5 v5.17.4/go.mod h1:KsAAI7eStAWwQa4F96MLy+whYSh39JzNjklZRbN/8ns=
-github.com/IBM/ibm-csi-common v1.1.27 h1:irwHXa0At/LofXLPOENcYU7To5UxHoFo7WUOWaJ1edM=
-github.com/IBM/ibm-csi-common v1.1.27/go.mod h1:qf0vG4gs+oTdHTpGP3ofJ9XaT6+IBsbfwfR9z/KBzoY=
-github.com/IBM/ibmcloud-volume-file-vpc v1.2.20 h1:RpOBRyOqFaDSl4CsQAABCqCr7IoHGoO7KSSKeKAn0yI=
-github.com/IBM/ibmcloud-volume-file-vpc v1.2.20/go.mod h1:3gjOrlJIN2SDJgtkOOjs4g/WkJgx+uJJAdDvHJbrh0s=
+github.com/IBM/ibm-csi-common v1.1.26 h1:Z+xRJUBpADdAVIffv8nODg3CMgcmwO0TAij5NHLomyI=
+github.com/IBM/ibm-csi-common v1.1.26/go.mod h1:qf0vG4gs+oTdHTpGP3ofJ9XaT6+IBsbfwfR9z/KBzoY=
+github.com/IBM/ibmcloud-volume-file-vpc v1.2.19 h1:kgeCQ5vYYNfxPqPpMjxLYrqRhzdDZqq1uPAWK+mWGgM=
+github.com/IBM/ibmcloud-volume-file-vpc v1.2.19/go.mod h1:3gjOrlJIN2SDJgtkOOjs4g/WkJgx+uJJAdDvHJbrh0s=
 github.com/IBM/ibmcloud-volume-interface v1.2.21 h1:7w7ZAY3F5DLfzaV4sLoC/4S0AYXZrUPHanrlBHaNb4c=
 github.com/IBM/ibmcloud-volume-interface v1.2.21/go.mod h1:lpon+MgOK9F0Q8AxZDG/dWXc9vJiiYfPri9ToskBA08=
 github.com/IBM/secret-common-lib v1.1.15 h1:r2oQE7UAjHiPHhUUWJmI1NYYmuTRHWENtFolTSbXMwI=

--- a/pkg/ibmcsidriver/constants.go
+++ b/pkg/ibmcsidriver/constants.go
@@ -163,9 +163,6 @@ const (
 	// EncryptionTransitMode ...
 	EncryptionTransitMode = "user_managed"
 
-	// IPSEC ...
-	IPSEC = "ipsec"
-
 	// VPC ...
 	VPC = "vpc"
 

--- a/pkg/ibmcsidriver/controller_helper.go
+++ b/pkg/ibmcsidriver/controller_helper.go
@@ -383,16 +383,6 @@ func getVolumeParameters(logger *zap.Logger, req *csi.CreateVolumeRequest, confi
 		volume.Az = zones[utils.NodeZoneLabel]
 	}
 
-	// if EIT enabled
-	if volume.TransitEncryption == EncryptionTransitMode && volume.VPCVolume.Profile.Name == DP2Profile {
-		volume.TransitEncryption = IPSEC
-	} else if volume.TransitEncryption == EncryptionTransitMode && volume.VPCVolume.Profile.Name == RFSProfile {
-		volume.TransitEncryption = "none"
-		return volume, fmt.Errorf("encryption in transit is not supported for rfs profile")
-	} else {
-		volume.TransitEncryption = "none" // default value
-	}
-
 	return volume, nil
 }
 
@@ -709,7 +699,7 @@ func createCSIVolumeResponse(vol provider.Volume, volAccessPointResponse provide
 	labels[NFSServerPath] = volAccessPointResponse.MountPath
 
 	// Update label in case EIT is enabled
-	if vol.TransitEncryption == IPSEC {
+	if vol.TransitEncryption == EncryptionTransitMode {
 		labels[IsEITEnabled] = TrueStr
 	}
 

--- a/pkg/ibmcsidriver/node.go
+++ b/pkg/ibmcsidriver/node.go
@@ -130,19 +130,13 @@ func (csiNS *CSINodeServer) NodePublishVolume(ctx context.Context, req *csi.Node
 	}
 	mnt := volumeCapability.GetMount()
 	options := mnt.MountFlags
-	profileName := req.GetVolumeContext()[ProfileLabel]
 
 	// find  FS type
 	fsType := defaultFsType
-
-	// In case EIT is enabled
-	var transitEncryption string
+	// In case EIT is enabled, use eitFsType
 	isEITEnabled := req.GetVolumeContext()[IsEITEnabled]
 	if isEITEnabled == TrueStr {
 		fsType = eitFsType
-		if profileName == DP2Profile {
-			transitEncryption = IPSEC
-		}
 	}
 
 	var nodePublishResponse *csi.NodePublishVolumeResponse
@@ -153,7 +147,7 @@ func (csiNS *CSINodeServer) NodePublishVolume(ctx context.Context, req *csi.Node
 	csiNS.mutex.Lock(target)
 	defer csiNS.mutex.Unlock(target)
 
-	nodePublishResponse, mountErr = csiNS.processMount(ctxLogger, requestID, source, target, fsType, transitEncryption, options)
+	nodePublishResponse, mountErr = csiNS.processMount(ctxLogger, requestID, source, target, fsType, options)
 
 	ctxLogger.Info("CSINodeServer-NodePublishVolume response...", zap.Reflect("Response", nodePublishResponse), zap.Error(mountErr))
 	return nodePublishResponse, mountErr

--- a/pkg/ibmcsidriver/node_helper.go
+++ b/pkg/ibmcsidriver/node_helper.go
@@ -28,7 +28,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (csiNS *CSINodeServer) processMount(ctxLogger *zap.Logger, requestID, mountPath, targetPath, fsType string, transitEncryption string, options []string) (*csi.NodePublishVolumeResponse, error) {
+func (csiNS *CSINodeServer) processMount(ctxLogger *zap.Logger, requestID, mountPath, targetPath, fsType string, options []string) (*csi.NodePublishVolumeResponse, error) {
 	mountPathField := zap.String("mountPath", mountPath)
 	targetPathField := zap.String("targetPath", targetPath)
 	fsTypeField := zap.String("fsType", fsType)
@@ -46,7 +46,7 @@ func (csiNS *CSINodeServer) processMount(ctxLogger *zap.Logger, requestID, mount
 	if fsType != eitFsType {
 		err = csiNS.Mounter.Mount(mountPath, targetPath, fsType, options)
 	} else {
-		errResponse, err = csiNS.Mounter.MountEITBasedFileShare(mountPath, targetPath, fsType, transitEncryption, requestID)
+		errResponse, err = csiNS.Mounter.MountEITBasedFileShare(mountPath, targetPath, fsType, requestID)
 	}
 
 	if err != nil {

--- a/pkg/ibmcsidriver/node_helper_test.go
+++ b/pkg/ibmcsidriver/node_helper_test.go
@@ -35,10 +35,10 @@ func TestProcessMount(t *testing.T) {
 
 	icDriver := initIBMCSIDriver(t)
 	ops := []string{"a", "b"}
-	response, err := icDriver.ns.processMount(logger, "processMount", "/staging", "/targetpath", "ext4", "", ops)
+	response, err := icDriver.ns.processMount(logger, "processMount", "/staging", "/targetpath", "ext4", ops)
 	t.Logf("Response %v, error %v", response, err)
 
-	response, err = icDriver.ns.processMount(logger, "processMount", "/staging", "/targetpath", "ibmshare", "ipsec", ops)
+	response, err = icDriver.ns.processMount(logger, "processMount", "/staging", "/targetpath", "ibmshare", ops)
 	t.Logf("Response %v, error %v", response, err)
 }
 


### PR DESCRIPTION
Reverts IBM/ibm-vpc-file-csi-driver#131

test-results -> https://github.ibm.com/alchemy-containers/armada-storage/issues/9773#issuecomment-210012936