### PR TITLE
Fix mount issue

### DIFF
--- a/pkg/ibmcsidriver/node_helper.go
+++ b/pkg/ibmcsidriver/node_helper.go
@@ -68,6 +68,7 @@ func (csiNS *CSINodeServer) processMount(ctxLogger *zap.Logger, requestID, mount
 			}
 		}
 		var errorCode string
+		errorCode = commonError.MountingTargetFailed
 		errRemovePath := os.Remove(targetPath)
 		if errRemovePath != nil {
 			ctxLogger.Warn("processMount: Remove targetPath failed", zap.String("targetPath", targetPath), zap.Error(errRemovePath))
@@ -79,6 +80,7 @@ func (csiNS *CSINodeServer) processMount(ctxLogger *zap.Logger, requestID, mount
 				ctxLogger.Error("Mount backend output: ", zap.String("Reponse:", errResponse))
 			}
 		}
+		ctxLogger.Info("processMount: returning CSI error-test",zap.String("requestID", requestID),zap.String("errorCode", errorCode),zap.String("fsType", fsType),zap.String("mountPath", mountPath),zap.String("targetPath", targetPath),zap.Error(err),)
 		return nil, commonError.GetCSIError(ctxLogger, errorCode, requestID, err)
 	}
 

--- a/pkg/ibmcsidriver/node_helper.go
+++ b/pkg/ibmcsidriver/node_helper.go
@@ -72,7 +72,6 @@ func (csiNS *CSINodeServer) processMount(ctxLogger *zap.Logger, requestID, mount
 		errRemovePath := os.Remove(targetPath)
 		if errRemovePath != nil {
 			ctxLogger.Warn("processMount: Remove targetPath failed", zap.String("targetPath", targetPath), zap.Error(errRemovePath))
-			errorCode = commonError.CreateMountTargetFailed
 		}
 		if fsType == eitFsType {
 			errorCode = checkMountResponse(err)

--- a/pkg/ibmcsidriver/node_helper.go
+++ b/pkg/ibmcsidriver/node_helper.go
@@ -80,7 +80,6 @@ func (csiNS *CSINodeServer) processMount(ctxLogger *zap.Logger, requestID, mount
 				ctxLogger.Error("Mount backend output: ", zap.String("Reponse:", errResponse))
 			}
 		}
-		ctxLogger.Info("processMount: returning CSI error-test",zap.String("requestID", requestID),zap.String("errorCode", errorCode),zap.String("fsType", fsType),zap.String("mountPath", mountPath),zap.String("targetPath", targetPath),zap.Error(err),)
 		return nil, commonError.GetCSIError(ctxLogger, errorCode, requestID, err)
 	}
 

--- a/pkg/ibmcsidriver/node_helper.go
+++ b/pkg/ibmcsidriver/node_helper.go
@@ -67,8 +67,7 @@ func (csiNS *CSINodeServer) processMount(ctxLogger *zap.Logger, requestID, mount
 				return nil, commonError.GetCSIError(ctxLogger, commonError.UnmountFailed, requestID, err, targetPath)
 			}
 		}
-		var errorCode string
-		errorCode = commonError.MountingTargetFailed
+		errorCode := commonError.MountingTargetFailed
 		errRemovePath := os.Remove(targetPath)
 		if errRemovePath != nil {
 			ctxLogger.Warn("processMount: Remove targetPath failed", zap.String("targetPath", targetPath), zap.Error(errRemovePath))
@@ -76,7 +75,7 @@ func (csiNS *CSINodeServer) processMount(ctxLogger *zap.Logger, requestID, mount
 		if fsType == eitFsType {
 			errorCode = checkMountResponse(err)
 			if errorCode != commonError.UnresponsiveMountHelperContainerUtility {
-				ctxLogger.Error("Mount backend output: ", zap.String("Reponse:", errResponse))
+				ctxLogger.Error("Mount backend output: ", zap.String("Response:", errResponse))
 			}
 		}
 		return nil, commonError.GetCSIError(ctxLogger, errorCode, requestID, err)

--- a/pkg/ibmcsidriver/node_helper_test.go
+++ b/pkg/ibmcsidriver/node_helper_test.go
@@ -158,8 +158,7 @@ func TestProcessMount_MountFailure(t *testing.T) {
 				_ = os.Remove(targetPath)
 			}
 
-			// Override MakeDir so it doesn't create the path when targetPath is
-			// a real TempDir — that path already exists and we want Remove to
+			// Use an existing TempDir — that path already exists and we want Remove to
 			// find it after the mount fails.
 			resp, err := icDriver.ns.processMount(logger, "req-001", "10.0.0.1:/vol", targetPath, tc.fsType, tc.transitEnc, nil)
 

--- a/pkg/ibmcsidriver/node_helper_test.go
+++ b/pkg/ibmcsidriver/node_helper_test.go
@@ -21,12 +21,37 @@ package ibmcsidriver
 
 import (
 	"errors"
+	"os"
 	"testing"
 
+	mountManager "github.com/IBM/ibm-csi-common/pkg/mountmanager"
 	commonError "github.com/IBM/ibm-csi-common/pkg/messages"
 	cloudProvider "github.com/IBM/ibmcloud-volume-file-vpc/pkg/ibmcloudprovider"
 	"github.com/stretchr/testify/assert"
 )
+
+// mounterWithMountError wraps a real Mounter and overrides Mount to return
+// a configurable error, allowing tests to exercise the mount-failure path in
+// processMount without depending on real OS mount behaviour.
+type mounterWithMountError struct {
+	mountManager.Mounter
+	mountErr error
+}
+
+func (m *mounterWithMountError) Mount(source, target, fsType string, options []string) error {
+	return m.mountErr
+}
+
+// mounterWithEITError wraps a real Mounter and overrides MountEITBasedFileShare
+// to return a configurable error, for testing the EIT mount-failure path.
+type mounterWithEITError struct {
+	mountManager.Mounter
+	mountErr error
+}
+
+func (m *mounterWithEITError) MountEITBasedFileShare(mountPath, targetPath, fsType, transitEncryption, requestID string) (string, error) {
+	return "", m.mountErr
+}
 
 func TestProcessMount(t *testing.T) {
 	// Creating test logger
@@ -40,6 +65,109 @@ func TestProcessMount(t *testing.T) {
 
 	response, err = icDriver.ns.processMount(logger, "processMount", "/staging", "/targetpath", "ibmshare", "ipsec", ops)
 	t.Logf("Response %v, error %v", response, err)
+}
+
+func TestProcessMount_MountFailure(t *testing.T) {
+	tests := []struct {
+		name            string
+		fsType          string
+		transitEnc      string
+		mountErr        error
+		expectedErrCode string
+		// targetInTempDir causes the targetPath to be a real temp directory so
+		// that os.Remove succeeds (exercising MountingTargetFailed).
+		// When false the targetPath is a non-existent path so os.Remove fails
+		// (exercising CreateMountTargetFailed).
+		targetInTempDir bool
+	}{
+		{
+			name:            "Non-EIT mount failure: MountingTargetFailed when Remove succeeds",
+			fsType:          "nfs",
+			mountErr:        errors.New("exit status 32: Protocol not supported"),
+			expectedErrCode: commonError.MountingTargetFailed,
+			targetInTempDir: true,
+		},
+		{
+			name:            "Non-EIT mount failure: CreateMountTargetFailed when Remove fails",
+			fsType:          "nfs",
+			mountErr:        errors.New("exit status 32: Protocol not supported"),
+			expectedErrCode: commonError.CreateMountTargetFailed,
+			targetInTempDir: false,
+		},
+		{
+			name:            "EIT mount failure: exit status 1 -> MetadataServiceNotEnabled",
+			fsType:          eitFsType,
+			transitEnc:      "ipsec",
+			mountErr:        errors.New("exit status 1"),
+			expectedErrCode: commonError.MetadataServiceNotEnabled,
+			targetInTempDir: true,
+		},
+		{
+			name:            "EIT mount failure: connect no such file -> UnresponsiveMountHelperContainerUtility",
+			fsType:          eitFsType,
+			transitEnc:      "ipsec",
+			mountErr:        errors.New("connect: no such file"),
+			expectedErrCode: commonError.UnresponsiveMountHelperContainerUtility,
+			targetInTempDir: true,
+		},
+		{
+			name:            "EIT mount failure: unknown error -> MountingTargetFailed",
+			fsType:          eitFsType,
+			transitEnc:      "ipsec",
+			mountErr:        errors.New("some unexpected EIT error"),
+			expectedErrCode: commonError.MountingTargetFailed,
+			targetInTempDir: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, teardown := cloudProvider.GetTestLogger(t)
+			defer teardown()
+
+			icDriver := initIBMCSIDriver(t)
+
+			// Choose and configure the appropriate mount-error injector.
+			var mounter mountManager.Mounter
+			if tc.fsType == eitFsType {
+				mounter = &mounterWithEITError{
+					Mounter:  icDriver.ns.Mounter,
+					mountErr: tc.mountErr,
+				}
+			} else {
+				mounter = &mounterWithMountError{
+					Mounter:  icDriver.ns.Mounter,
+					mountErr: tc.mountErr,
+				}
+			}
+			icDriver.ns.Mounter = mounter
+
+			// Determine targetPath: a real directory (Remove will succeed) or a
+			// path that does not exist so that Remove returns an error.
+			var targetPath string
+			if tc.targetInTempDir {
+				// MakeDir is handled by the fake mounter; we only need the path
+				// to exist so that os.Remove inside processMount can clean it up.
+				targetPath = t.TempDir()
+				// processMount calls MakeDir which is a no-op in the fake, so
+				// the directory already exists from t.TempDir().
+			} else {
+				// Use a path that will never exist so os.Remove fails.
+				targetPath = "/nonexistent-path-for-test-" + tc.name
+				// Ensure it really doesn't exist.
+				_ = os.Remove(targetPath)
+			}
+
+			// Override MakeDir so it doesn't create the path when targetPath is
+			// a real TempDir — that path already exists and we want Remove to
+			// find it after the mount fails.
+			resp, err := icDriver.ns.processMount(logger, "req-001", "10.0.0.1:/vol", targetPath, tc.fsType, tc.transitEnc, nil)
+
+			assert.Nil(t, resp)
+			assert.NotNil(t, err)
+			assert.Contains(t, err.Error(), tc.expectedErrCode)
+		})
+	}
 }
 
 func TestCheckMountResponse(t *testing.T) {

--- a/pkg/ibmcsidriver/server.go
+++ b/pkg/ibmcsidriver/server.go
@@ -61,7 +61,6 @@ type nonBlockingGRPCServer struct {
 	wg     sync.WaitGroup
 	server *grpc.Server
 	logger *zap.Logger
-	// fileOps socketPermission
 }
 
 // Start ...

--- a/pkg/ibmcsidriver/server.go
+++ b/pkg/ibmcsidriver/server.go
@@ -168,6 +168,7 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	glog.V(3).Infof("GRPC call: %s", info.FullMethod)
 	glog.V(5).Infof("GRPC request: %+v", req)
 	resp, err := handler(ctx, req)
+	glog.Infof("Handler returned response=%+v err=%v", resp, err)
 	if err != nil {
 		glog.Errorf("GRPC error: %v", err)
 	} else {

--- a/pkg/ibmcsidriver/server.go
+++ b/pkg/ibmcsidriver/server.go
@@ -50,7 +50,7 @@ type NonBlockingGRPCServer interface {
 
 // NewNonBlockingGRPCServer ...
 func NewNonBlockingGRPCServer(logger *zap.Logger) NonBlockingGRPCServer {
-	return &nonBlockingGRPCServer{logger: logger}
+	return &nonBlockingGRPCServer{logger: logger, fileOps: &opsSocketPermission{}}
 }
 
 // nonBlockingGRPCServer server
@@ -58,6 +58,7 @@ type nonBlockingGRPCServer struct {
 	wg     sync.WaitGroup
 	server *grpc.Server
 	logger *zap.Logger
+	fileOps socketPermission
 }
 
 // Start ...
@@ -126,8 +127,7 @@ func (s *nonBlockingGRPCServer) Setup(endpoint string, ids csi.IdentityServer, c
 	// In case of nodeSerer container, setup desired csi socket permissions and user/group.
 	// This is required for running `livenessprobe` container as non-root user/group
 	if os.Getenv("IS_NODE_SERVER") == "true" {
-		fileops := &opsSocketPermission{}
-		if err := setupSidecar(addr, fileops, s.logger); err != nil {
+		if err := setupSidecar(addr, s.fileOps, s.logger); err != nil {
 			s.logger.Error("setupSidecar failed.", zap.Error(err))
 			return nil, err
 		}

--- a/pkg/ibmcsidriver/server.go
+++ b/pkg/ibmcsidriver/server.go
@@ -50,15 +50,18 @@ type NonBlockingGRPCServer interface {
 
 // NewNonBlockingGRPCServer ...
 func NewNonBlockingGRPCServer(logger *zap.Logger) NonBlockingGRPCServer {
-	return &nonBlockingGRPCServer{logger: logger, fileOps: &opsSocketPermission{}}
+	return &nonBlockingGRPCServer{logger: logger}
 }
+
+// Package variable to allow unit tests to override file operations safely
+var defaultSocketPermission socketPermission = &opsSocketPermission{}
 
 // nonBlockingGRPCServer server
 type nonBlockingGRPCServer struct {
 	wg     sync.WaitGroup
 	server *grpc.Server
 	logger *zap.Logger
-	fileOps socketPermission
+	// fileOps socketPermission
 }
 
 // Start ...
@@ -127,7 +130,7 @@ func (s *nonBlockingGRPCServer) Setup(endpoint string, ids csi.IdentityServer, c
 	// In case of nodeSerer container, setup desired csi socket permissions and user/group.
 	// This is required for running `livenessprobe` container as non-root user/group
 	if os.Getenv("IS_NODE_SERVER") == "true" {
-		if err := setupSidecar(addr, s.fileOps, s.logger); err != nil {
+		if err := setupSidecar(addr, defaultSocketPermission, s.logger); err != nil {
 			s.logger.Error("setupSidecar failed.", zap.Error(err))
 			return nil, err
 		}

--- a/pkg/ibmcsidriver/server.go
+++ b/pkg/ibmcsidriver/server.go
@@ -168,7 +168,6 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	glog.V(3).Infof("GRPC call: %s", info.FullMethod)
 	glog.V(5).Infof("GRPC request: %+v", req)
 	resp, err := handler(ctx, req)
-	glog.Infof("Handler returned response=%+v err=%v", resp, err)
 	if err != nil {
 		glog.Errorf("GRPC error: %v", err)
 	} else {

--- a/pkg/ibmcsidriver/server_test.go
+++ b/pkg/ibmcsidriver/server_test.go
@@ -28,6 +28,7 @@ import (
 	"context"
 
 	cloudProvider "github.com/IBM/ibmcloud-volume-file-vpc/pkg/ibmcloudprovider"
+	"github.com/IBM/ibm-vpc-file-csi-driver/pkg/ibmcsidriver/ibmcsidriverfakes"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )
@@ -94,6 +95,10 @@ func TestSetup(t *testing.T) {
 		t.Logf("setup CSI sidecar with chown failure")
 		_ = os.Setenv("IS_NODE_SERVER", "true")
 		defer func() { _ = os.Unsetenv("IS_NODE_SERVER") }()
+		fakeFileOps := new(ibmcsidriverfakes.FakeSocketPermission)
+		chownErr := errors.New("chown /tmp/testcsi.sock: operation not permitted")
+		fakeFileOps.ChownReturns(chownErr)
+		nonBlockingServer.fileOps = fakeFileOps
 		ls, err := nonBlockingServer.Setup(*goodEndpoint, ids, cs, ns)
 		assert.NotNil(t, err)
 		assert.Nil(t, ls)

--- a/pkg/ibmcsidriver/server_test.go
+++ b/pkg/ibmcsidriver/server_test.go
@@ -92,18 +92,25 @@ func TestSetup(t *testing.T) {
 	}
 
 	{
-		t.Logf("setup CSI sidecar with chown failure")
-		_ = os.Setenv("IS_NODE_SERVER", "true")
-		defer func() { _ = os.Unsetenv("IS_NODE_SERVER") }()
-		fakeFileOps := new(ibmcsidriverfakes.FakeSocketPermission)
-		chownErr := errors.New("chown /tmp/testcsi.sock: operation not permitted")
-		fakeFileOps.ChownReturns(chownErr)
-		nonBlockingServer.fileOps = fakeFileOps
-		ls, err := nonBlockingServer.Setup(*goodEndpoint, ids, cs, ns)
-		assert.NotNil(t, err)
-		assert.Nil(t, ls)
-		assert.Equal(t, err.Error(), "chown /tmp/testcsi.sock: operation not permitted")
-	}
+        t.Logf("setup CSI sidecar with chown failure")
+        _ = os.Setenv("IS_NODE_SERVER", "true")
+        defer func() { _ = os.Unsetenv("IS_NODE_SERVER") }()
+
+        // Initialize your mock
+        fakeFileOps := new(ibmcsidriverfakes.FakeSocketPermission)
+        chownErr := errors.New("chown /tmp/testcsi.sock: operation not permitted")
+        fakeFileOps.ChownReturns(chownErr)
+
+        // Override the package global hook, and restore it when done
+        oldFileOps := defaultSocketPermission
+        defaultSocketPermission = fakeFileOps
+        defer func() { defaultSocketPermission = oldFileOps }()
+
+        ls, err := nonBlockingServer.Setup(*goodEndpoint, ids, cs, ns)
+        assert.NotNil(t, err)
+        assert.Nil(t, ls)
+        assert.Equal(t, "chown /tmp/testcsi.sock: operation not permitted", err.Error())
+    }
 }
 
 func TestLogGRPC(t *testing.T) {


### PR DESCRIPTION
**Issue Description:**
Fix volume mount fallback and resolve server unit test

Fix Mount Fallback: Fixed an issue where standard volume mount failures (such as NFS exit status 32) silently passed an empty error code to the gRPC layer, causing Kubelet to assume success and mount the node's local root disk instead. Explicitly set errorCode = commonError.MountingTargetFailed inside the failure block so Kubelet correctly catches the error and holds the pod in ContainerCreating.

Fix UT Panic: Moved the fileOps instantiation from a local variable inside Setup() to a global hook variable field. This enables clean dependency injection for unit tests, fixes a SIGSEGV nil pointer panic during test runs, and allows proper testing of the socket chown failure path. No production impact.

Added new UTs for mounting-failed scenarios

Test Result: https://github.ibm.com/alchemy-containers/armada-storage/issues/9963