### PR TITLE
Go, dreadnaught image and other package upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/sys v0.45.0
-	google.golang.org/grpc v1.81.1
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4

--- a/go.sum
+++ b/go.sum
@@ -451,8 +451,8 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
Task Detail :->
DreadNaught image versions are upgraded due to reported VA.

Compliance Issue Details :->
[CVE-2026-5928](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2026-5928)
[CVE-2026-6238](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2026-6238)
[CVE-2026-5435](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2026-5435)
[GHSA-hrxh-6v49-42gf](https://exchange.xforce.ibmcloud.com/vulnerabilities/GHSA-hrxh-6v49-42gf)
[CVE-2026-54370](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2026-54370)
[CVE-2026-54369](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2026-54369)

Updation Area :->
Dreadnaught image upgrade from v9.8.75 to v9.8.85
```
>  ic cr va icr.io/ibm-dreadnought-prod-images/ubi9/golang-1.25-builder:v9.8.85
Checking security issues for 'icr.io/ibm-dreadnought-prod-images/ubi9/golang-1.25-builder:v9.8.85'...

Image 'icr.io/ibm-dreadnought-prod-images/ubi9/golang-1.25-builder:v9.8.85' was last scanned on Sun Jul 26 14:49:36 UTC 2026
The scan results show that NO ISSUES were found for the image.

OK

```
