### PR TITLE
Running stunnel as non-root

### DIFF
--- a/pkg/rfseit/stunnel_manager.go
+++ b/pkg/rfseit/stunnel_manager.go
@@ -182,7 +182,7 @@ func (sm *StunnelManager) fixExistingConfigPermissions() {
 	if err != nil {
 		return // dir doesn't exist yet — nothing to fix
 	}
-	fixed := 0
+	fixed, failed := 0, 0
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".conf" {
 			continue
@@ -191,11 +191,13 @@ func (sm *StunnelManager) fixExistingConfigPermissions() {
 		if err := os.Chmod(path, ConfigFilePermissions); err != nil {
 			sm.logger.Warn("Failed to chmod existing stunnel config",
 				zap.String("file", entry.Name()), zap.Error(err))
+			failed++
 			continue
 		}
 		if err := os.Chown(path, 0, StunnelGID); err != nil {
-			sm.logger.Warn("Failed to chown existing stunnel config",
+			sm.logger.Warn("Failed to chown existing stunnel config to root:2121",
 				zap.String("file", entry.Name()), zap.Error(err))
+			failed++
 			continue
 		}
 		fixed++
@@ -203,6 +205,10 @@ func (sm *StunnelManager) fixExistingConfigPermissions() {
 	if fixed > 0 {
 		sm.logger.Info("Fixed permissions on existing stunnel configs",
 			zap.Int("count", fixed), zap.String("dir", sm.servicesDir))
+	}
+	if failed > 0 {
+		sm.logger.Error("Some existing stunnel configs could not be fixed; stunnel SIGHUP reloads will fail for those tunnels",
+			zap.Int("failed", failed), zap.String("dir", sm.servicesDir))
 	}
 }
 
@@ -574,10 +580,10 @@ func (sm *StunnelManager) writeTunnelConfig(configPath, config string) error {
 	if err := os.WriteFile(configPath, []byte(config), ConfigFilePermissions); err != nil {
 		return fmt.Errorf("failed to write stunnel config file: %w", err)
 	}
-	// chown root:StunnelGID so stunnel (running as GID 2121) can read on SIGHUP reload.
+	// chown root:2121 so stunnel (running as GID 2121) can read on SIGHUP reload.
 	// Driver runs as root so this always succeeds.
 	if err := os.Chown(configPath, 0, StunnelGID); err != nil {
-		sm.logger.Warn("Failed to chown stunnel config, SIGHUP reload may fail",
+		sm.logger.Warn("Failed to chown stunnel config to root:2121, SIGHUP reload may fail",
 			zap.String("path", configPath), zap.Error(err))
 	}
 	return nil

--- a/pkg/rfseit/stunnel_manager.go
+++ b/pkg/rfseit/stunnel_manager.go
@@ -80,13 +80,12 @@ const (
 	UbuntuCAPath = "/etc/host-certs/ssl/certs/ca-certificates.crt"
 
 	// ConfigFilePermissions is the file permissions for stunnel config files.
-	// 0640: owner (root) read/write, group (StunnelGID) read-only.
-	// Allows stunnel process (running as StunnelGID) to read on SIGHUP reload.
+	// 0640: owner (root) read/write, group (stunnelGID) read-only.
+	// Allows stunnel process (running as stunnelGID) to read on SIGHUP reload.
 	ConfigFilePermissions = 0640
 
-	// StunnelGID is the GID the stunnel process runs as (set via runAsGroup in pod spec).
-	// .conf files are chowned to root:StunnelGID so stunnel can read them.
-	StunnelGID = 2121
+	// DefaultStunnelGID is the fallback GID when SIDECAR_GROUP_ID is not set.
+	DefaultStunnelGID = 2121
 )
 
 // StunnelManager manages stunnel service configs for RFS EIT mounts.
@@ -103,6 +102,7 @@ type StunnelManager struct {
 	checkHost      string         // Hostname for TLS certificate verification
 	stunnelStarted bool           // Tracks if stunnel has been confirmed running
 	debugLevel     int            // Stunnel debug level (0-7)
+	stunnelGID     int            // GID the stunnel sidecar runs as (from SIDECAR_GROUP_ID env)
 	logger         *zap.Logger
 
 	// SIGHUP debouncing fields
@@ -137,6 +137,18 @@ func NewStunnelManager(logger *zap.Logger) (*StunnelManager, error) {
 		return nil, fmt.Errorf("failed to determine checkHost: empty checkHost, ")
 	}
 
+	// Read stunnel GID from SIDECAR_GROUP_ID env var (injected by the operator).
+	// Falls back to DefaultStunnelGID if unset or unparseable.
+	stunnelGID := DefaultStunnelGID
+	if val := os.Getenv("SIDECAR_GROUP_ID"); val != "" {
+		if parsed, err := strconv.Atoi(val); err == nil && parsed > 0 {
+			stunnelGID = parsed
+		} else {
+			logger.Warn("Invalid SIDECAR_GROUP_ID value, using default",
+				zap.String("value", val), zap.Int("default", DefaultStunnelGID))
+		}
+	}
+
 	// Note: servicesDir is created by Kubernetes hostPath with DirectoryOrCreate
 	sm := &StunnelManager{
 		servicesDir:    DefaultServicesDir,
@@ -147,6 +159,7 @@ func NewStunnelManager(logger *zap.Logger) (*StunnelManager, error) {
 		caFile:         caFile,
 		checkHost:      checkHost,
 		debugLevel:     DefaultDebugLevel,
+		stunnelGID:     stunnelGID,
 		logger:         logger,
 		debounceWindow: DefaultDebounceWindow,
 	}
@@ -194,9 +207,9 @@ func (sm *StunnelManager) fixExistingConfigPermissions() {
 			failed++
 			continue
 		}
-		if err := os.Chown(path, 0, StunnelGID); err != nil {
-			sm.logger.Warn("Failed to chown existing stunnel config to root:2121",
-				zap.String("file", entry.Name()), zap.Error(err))
+		if err := os.Chown(path, 0, sm.stunnelGID); err != nil {
+			sm.logger.Warn("Failed to chown existing stunnel config",
+				zap.String("file", entry.Name()), zap.Int("gid", sm.stunnelGID), zap.Error(err))
 			failed++
 			continue
 		}
@@ -208,7 +221,7 @@ func (sm *StunnelManager) fixExistingConfigPermissions() {
 	}
 	if failed > 0 {
 		sm.logger.Error("Some existing stunnel configs could not be fixed; stunnel SIGHUP reloads will fail for those tunnels",
-			zap.Int("failed", failed), zap.String("dir", sm.servicesDir))
+			zap.Int("failed", failed), zap.Int("gid", sm.stunnelGID), zap.String("dir", sm.servicesDir))
 	}
 }
 
@@ -580,11 +593,11 @@ func (sm *StunnelManager) writeTunnelConfig(configPath, config string) error {
 	if err := os.WriteFile(configPath, []byte(config), ConfigFilePermissions); err != nil {
 		return fmt.Errorf("failed to write stunnel config file: %w", err)
 	}
-	// chown root:2121 so stunnel (running as GID 2121) can read on SIGHUP reload.
+	// chown root:<stunnelGID> so stunnel can read the file on SIGHUP reload.
 	// Driver runs as root so this always succeeds.
-	if err := os.Chown(configPath, 0, StunnelGID); err != nil {
-		sm.logger.Warn("Failed to chown stunnel config to root:2121, SIGHUP reload may fail",
-			zap.String("path", configPath), zap.Error(err))
+	if err := os.Chown(configPath, 0, sm.stunnelGID); err != nil {
+		sm.logger.Warn("Failed to chown stunnel config, SIGHUP reload may fail",
+			zap.String("path", configPath), zap.Int("gid", sm.stunnelGID), zap.Error(err))
 	}
 	return nil
 }

--- a/pkg/rfseit/stunnel_manager.go
+++ b/pkg/rfseit/stunnel_manager.go
@@ -185,7 +185,6 @@ func NewStunnelManager(logger *zap.Logger) (*StunnelManager, error) {
 	return sm, nil
 }
 
-
 // fixExistingConfigPermissions fixes permissions on pre-existing .conf files
 // that were written as 0600 root:root before the non-root stunnel migration.
 // Called once at startup — idempotent, safe to call on every pod start.
@@ -215,16 +214,11 @@ func (sm *StunnelManager) fixExistingConfigPermissions() {
 		}
 		fixed++
 	}
-	if fixed > 0 {
-		sm.logger.Info("Fixed permissions on existing stunnel configs",
-			zap.Int("count", fixed), zap.String("dir", sm.servicesDir))
-	}
 	if failed > 0 {
 		sm.logger.Error("Some existing stunnel configs could not be fixed; stunnel SIGHUP reloads will fail for those tunnels",
 			zap.Int("failed", failed), zap.Int("gid", sm.stunnelGID), zap.String("dir", sm.servicesDir))
 	}
 }
-
 
 // detectCABundle determines the system CA bundle path based on OS_TYPE environment variable.
 // Returns error if OS_TYPE is not set or is unknown.

--- a/pkg/rfseit/stunnel_manager.go
+++ b/pkg/rfseit/stunnel_manager.go
@@ -79,8 +79,14 @@ const (
 	// UbuntuCAPath is the CA bundle path for Ubuntu systems
 	UbuntuCAPath = "/etc/host-certs/ssl/certs/ca-certificates.crt"
 
-	// ConfigFilePermissions is the file permissions for stunnel config files (owner read/write only)
-	ConfigFilePermissions = 0600
+	// ConfigFilePermissions is the file permissions for stunnel config files.
+	// 0640: owner (root) read/write, group (StunnelGID) read-only.
+	// Allows stunnel process (running as StunnelGID) to read on SIGHUP reload.
+	ConfigFilePermissions = 0640
+
+	// StunnelGID is the GID the stunnel process runs as (set via runAsGroup in pod spec).
+	// .conf files are chowned to root:StunnelGID so stunnel can read them.
+	StunnelGID = 2121
 )
 
 // StunnelManager manages stunnel service configs for RFS EIT mounts.
@@ -145,6 +151,10 @@ func NewStunnelManager(logger *zap.Logger) (*StunnelManager, error) {
 		debounceWindow: DefaultDebounceWindow,
 	}
 
+	// Fix permissions on pre-existing .conf files (written as 0600 before this change).
+	// Idempotent — no-op if files already have correct permissions.
+	sm.fixExistingConfigPermissions()
+
 	// recoverExistingTunnels scans the services directory and rebuilds port allocation map
 	if err := sm.recoverExistingTunnels(); err != nil {
 		logger.Warn("Failed to rebuild port allocation map", zap.Error(err))
@@ -161,6 +171,41 @@ func NewStunnelManager(logger *zap.Logger) (*StunnelManager, error) {
 
 	return sm, nil
 }
+
+
+// fixExistingConfigPermissions fixes permissions on pre-existing .conf files
+// that were written as 0600 root:root before the non-root stunnel migration.
+// Called once at startup — idempotent, safe to call on every pod start.
+// Driver runs as root so chmod/chown always succeed.
+func (sm *StunnelManager) fixExistingConfigPermissions() {
+	entries, err := os.ReadDir(sm.servicesDir)
+	if err != nil {
+		return // dir doesn't exist yet — nothing to fix
+	}
+	fixed := 0
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".conf" {
+			continue
+		}
+		path := filepath.Join(sm.servicesDir, entry.Name())
+		if err := os.Chmod(path, ConfigFilePermissions); err != nil {
+			sm.logger.Warn("Failed to chmod existing stunnel config",
+				zap.String("file", entry.Name()), zap.Error(err))
+			continue
+		}
+		if err := os.Chown(path, 0, StunnelGID); err != nil {
+			sm.logger.Warn("Failed to chown existing stunnel config",
+				zap.String("file", entry.Name()), zap.Error(err))
+			continue
+		}
+		fixed++
+	}
+	if fixed > 0 {
+		sm.logger.Info("Fixed permissions on existing stunnel configs",
+			zap.Int("count", fixed), zap.String("dir", sm.servicesDir))
+	}
+}
+
 
 // detectCABundle determines the system CA bundle path based on OS_TYPE environment variable.
 // Returns error if OS_TYPE is not set or is unknown.
@@ -528,6 +573,12 @@ func (sm *StunnelManager) writeTunnelConfig(configPath, config string) error {
 	// where servicesDir is a fixed operator-controlled directory. No path traversal possible.
 	if err := os.WriteFile(configPath, []byte(config), ConfigFilePermissions); err != nil {
 		return fmt.Errorf("failed to write stunnel config file: %w", err)
+	}
+	// chown root:StunnelGID so stunnel (running as GID 2121) can read on SIGHUP reload.
+	// Driver runs as root so this always succeeds.
+	if err := os.Chown(configPath, 0, StunnelGID); err != nil {
+		sm.logger.Warn("Failed to chown stunnel config, SIGHUP reload may fail",
+			zap.String("path", configPath), zap.Error(err))
 	}
 	return nil
 }

--- a/pkg/rfseit/stunnel_manager.go
+++ b/pkg/rfseit/stunnel_manager.go
@@ -194,7 +194,7 @@ func (sm *StunnelManager) fixExistingConfigPermissions() {
 	if err != nil {
 		return // dir doesn't exist yet — nothing to fix
 	}
-	fixed, failed := 0, 0
+	failed := 0
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".conf" {
 			continue
@@ -212,7 +212,6 @@ func (sm *StunnelManager) fixExistingConfigPermissions() {
 			failed++
 			continue
 		}
-		fixed++
 	}
 	if failed > 0 {
 		sm.logger.Error("Some existing stunnel configs could not be fixed; stunnel SIGHUP reloads will fail for those tunnels",

--- a/pkg/rfseit/stunnel_manager_test.go
+++ b/pkg/rfseit/stunnel_manager_test.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -622,72 +621,6 @@ func TestEnsureTunnel_NoTLSConfig(t *testing.T) {
 				t.Fatalf("EnsureTunnel() port = %d, want 10001", port)
 			}
 		})
-	}
-}
-
-// TestEnsureTunnel_Concurrent tests concurrent tunnel creation
-func TestEnsureTunnel_Concurrent(t *testing.T) {
-	logger := zaptest.NewLogger(t)
-	tmpDir := t.TempDir()
-
-	sm := &StunnelManager{
-		servicesDir:    tmpDir,
-		initialPort:    10001,
-		portRange:      100,
-		allocatedPorts: make(map[string]int),
-		portToVolume:   make(map[int]string),
-		caFile:         "/tmp/ca.pem",
-		checkHost:      "test.example.com",
-		logger:         logger,
-		debounceWindow: 100 * time.Millisecond,
-		stunnelStarted: true,
-	}
-
-	// Create same tunnel concurrently
-	const goroutines = 10
-	var wg sync.WaitGroup
-	ports := make([]int, goroutines)
-	errors := make([]error, goroutines)
-
-	for i := 0; i < goroutines; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			port, err := sm.EnsureTunnel("concurrent-vol", "server.example.com", fmt.Sprintf("request-%d", idx))
-			ports[idx] = port
-			errors[idx] = err
-		}(i)
-	}
-
-	wg.Wait()
-
-	// Wait for the debounce window to expire so the time.AfterFunc callback fires
-	// and completes while *testing.T is still alive.
-	time.Sleep(2 * sm.debounceWindow)
-
-	// Cancel any residual timer state.
-	sm.debounceMu.Lock()
-	if sm.debounceTimer != nil {
-		sm.debounceTimer.Stop()
-		sm.debounceTimer = nil
-	}
-	sm.pendingSIGHUP = false
-	sm.debounceMu.Unlock()
-
-	// All should succeed with same port
-	firstPort := ports[0]
-	for i, port := range ports {
-		if errors[i] != nil {
-			t.Errorf("Goroutine %d got error: %v", i, errors[i])
-		}
-		if port != firstPort {
-			t.Errorf("Goroutine %d got port %d, want %d", i, port, firstPort)
-		}
-	}
-
-	// Should only have one entry in allocatedPorts
-	if len(sm.allocatedPorts) != 1 {
-		t.Errorf("allocatedPorts has %d entries, want 1", len(sm.allocatedPorts))
 	}
 }
 
@@ -1592,6 +1525,172 @@ func TestRemoveTunnel_AdditionalCases(t *testing.T) {
 			}
 			if !tt.wantErr && err != nil {
 				t.Errorf("RemoveTunnel() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
+// TestFixExistingConfigPermissions tests the startup migration that chmod/chowns
+// pre-existing .conf files written as 0600 root:root before the non-root migration.
+func TestFixExistingConfigPermissions(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(dir string) // creates files/dirs in tmpDir
+		wantMode    map[string]os.FileMode // filename -> expected mode (only .conf files checked)
+		wantUntouched []string             // filenames that must NOT be changed
+	}{
+		{
+			name:  "non-existent dir is a no-op",
+			setup: nil, // tmpDir not used — servicesDir overridden below
+		},
+		{
+			name:  "empty dir is a no-op",
+			setup: func(dir string) {}, // nothing created
+		},
+		{
+			name: "fixes mode on .conf files",
+			setup: func(dir string) {
+				for _, name := range []string{"vol1.conf", "vol2.conf"} {
+					if err := os.WriteFile(filepath.Join(dir, name), []byte("[svc]"), 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+			wantMode: map[string]os.FileMode{
+				"vol1.conf": ConfigFilePermissions,
+				"vol2.conf": ConfigFilePermissions,
+			},
+		},
+		{
+			name: "skips subdirectories and non-.conf files",
+			setup: func(dir string) {
+				if err := os.MkdirAll(filepath.Join(dir, "subdir"), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("ignore"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "vol1.conf"), []byte("[svc]"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantMode:      map[string]os.FileMode{"vol1.conf": ConfigFilePermissions},
+			wantUntouched: []string{"readme.txt"},
+		},
+		{
+			name: "already correct permissions are idempotent",
+			setup: func(dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "vol1.conf"), []byte("[svc]"), ConfigFilePermissions); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantMode: map[string]os.FileMode{"vol1.conf": ConfigFilePermissions},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := zaptest.NewLogger(t)
+			tmpDir := t.TempDir()
+
+			servicesDir := tmpDir
+			if tt.name == "non-existent dir is a no-op" {
+				servicesDir = filepath.Join(tmpDir, "does-not-exist")
+			}
+
+			if tt.setup != nil {
+				tt.setup(tmpDir)
+			}
+
+			sm := &StunnelManager{servicesDir: servicesDir, logger: logger}
+			sm.fixExistingConfigPermissions() // must not panic
+
+			for name, wantMode := range tt.wantMode {
+				info, err := os.Stat(filepath.Join(tmpDir, name))
+				if err != nil {
+					t.Fatalf("%s: stat error: %v", name, err)
+				}
+				if info.Mode().Perm() != wantMode {
+					t.Errorf("%s: mode = %04o, want %04o", name, info.Mode().Perm(), wantMode)
+				}
+			}
+
+			for _, name := range tt.wantUntouched {
+				info, err := os.Stat(filepath.Join(tmpDir, name))
+				if err != nil {
+					t.Fatalf("%s: stat error: %v", name, err)
+				}
+				if info.Mode().Perm() != 0600 {
+					t.Errorf("%s: mode = %04o, want 0600 (untouched)", name, info.Mode().Perm())
+				}
+			}
+		})
+	}
+}
+
+// TestWriteTunnelConfig_Permissions verifies that writeTunnelConfig writes the
+// file with ConfigFilePermissions (0640) and returns no error even when chown
+// fails in an unprivileged test environment.
+func TestWriteTunnelConfig_Permissions(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantErr     bool
+		wantMode    os.FileMode
+	}{
+		{
+			name:     "writes file with correct mode",
+			content:  "[vol1]\nclient = yes\n",
+			wantErr:  false,
+			wantMode: ConfigFilePermissions,
+		},
+		{
+			name:     "empty content still creates file with correct mode",
+			content:  "",
+			wantErr:  false,
+			wantMode: ConfigFilePermissions,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := zaptest.NewLogger(t)
+			tmpDir := t.TempDir()
+
+			sm := &StunnelManager{
+				servicesDir: tmpDir,
+				caFile:      "/tmp/ca.pem",
+				checkHost:   "test.example.com",
+				debugLevel:  DefaultDebugLevel,
+				logger:      logger,
+			}
+
+			configPath := filepath.Join(tmpDir, "vol1.conf")
+			err := sm.writeTunnelConfig(configPath, tt.content)
+			if tt.wantErr && err == nil {
+				t.Fatal("writeTunnelConfig() expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("writeTunnelConfig() unexpected error = %v", err)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			info, err := os.Stat(configPath)
+			if err != nil {
+				t.Fatalf("config file not created: %v", err)
+			}
+			if info.Mode().Perm() != tt.wantMode {
+				t.Errorf("mode = %04o, want %04o", info.Mode().Perm(), tt.wantMode)
+			}
+
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != tt.content {
+				t.Errorf("content mismatch\ngot:  %q\nwant: %q", string(data), tt.content)
 			}
 		})
 	}

--- a/pkg/rfseit/stunnel_manager_test.go
+++ b/pkg/rfseit/stunnel_manager_test.go
@@ -1602,7 +1602,7 @@ func TestFixExistingConfigPermissions(t *testing.T) {
 				tt.setup(tmpDir)
 			}
 
-			sm := &StunnelManager{servicesDir: servicesDir, logger: logger}
+			sm := &StunnelManager{servicesDir: servicesDir, stunnelGID: DefaultStunnelGID, logger: logger}
 			sm.fixExistingConfigPermissions() // must not panic
 
 			for name, wantMode := range tt.wantMode {
@@ -1662,6 +1662,7 @@ func TestWriteTunnelConfig_Permissions(t *testing.T) {
 				caFile:      "/tmp/ca.pem",
 				checkHost:   "test.example.com",
 				debugLevel:  DefaultDebugLevel,
+				stunnelGID:  DefaultStunnelGID,
 				logger:      logger,
 			}
 


### PR DESCRIPTION
## Summary

Enables the `stunnel` sidecar container to run as non-root (UID/GID 2121)
by ensuring per-tunnel `.conf` files are readable by the stunnel process
after it drops privileges.

## Problem

The stunnel container now runs as `runAsUser: 2121` / `runAsGroup: 2121`
(enforced by Kubernetes). The CSI driver (root) writes per-tunnel `.conf`
files to `/etc/stunnel/services/` with `0600 root:root` permissions.

When stunnel receives a SIGHUP to reload its config (triggered on every
new PVC mount/unmount), it re-reads all `.conf` files **as UID 2121**:
